### PR TITLE
Add ReferenceLoopProneValueCollection

### DIFF
--- a/Nemesis.Essentials.Tests/ReferenceLoopProneValueCollectionTests.cs
+++ b/Nemesis.Essentials.Tests/ReferenceLoopProneValueCollectionTests.cs
@@ -1,0 +1,52 @@
+﻿using System.Collections.Generic;
+using Nemesis.Essentials.Design;
+using NUnit.Framework;
+
+namespace Nemesis.Essentials.Tests
+{
+    [TestFixture(TestOf = typeof(ReferenceLoopProneValueCollection<>))]
+    public class ReferenceLoopProneValueCollectionTests
+    {
+        private const string LoopDetectedNotification = "## SELF REFERENCING LOOP DETECTED ##";
+
+        public record A
+        {
+            public ICollection<B> Collection = new ReferenceLoopProneValueCollection<B>();
+        }
+
+        public record B (A A)
+        {
+            public A A { get; } = A;
+        }
+
+        [Test]
+        public void LoopDetected()
+        {
+            //Arrange
+            var a = new A();
+            var b = new B(a);
+            a.Collection.Add(b);
+
+            //Act
+            var aToString = a.ToString();
+
+            //Assert
+            Assert.True(aToString.Contains(LoopDetectedNotification));
+        }
+
+        [Test]
+        public void LoopNotDetected()
+        {
+            //Arrange
+            var a = new A();
+            var b = new B(null);
+            a.Collection.Add(b);
+
+            //Act
+            var aToString = a.ToString();
+
+            //Assert
+            Assert.False(aToString.Contains(LoopDetectedNotification));
+        }
+    }
+}

--- a/Nemesis.Essentials.Tests/ReferenceLoopProneValueCollectionTests.cs
+++ b/Nemesis.Essentials.Tests/ReferenceLoopProneValueCollectionTests.cs
@@ -7,8 +7,6 @@ namespace Nemesis.Essentials.Tests
     [TestFixture(TestOf = typeof(ReferenceLoopProneValueCollection<>))]
     public class ReferenceLoopProneValueCollectionTests
     {
-        private const string LoopDetectedNotification = "## SELF REFERENCING LOOP DETECTED ##";
-
         public record A
         {
             public ICollection<B> Collection = new ReferenceLoopProneValueCollection<B>();
@@ -31,7 +29,7 @@ namespace Nemesis.Essentials.Tests
             var aToString = a.ToString();
 
             //Assert
-            Assert.True(aToString.Contains(LoopDetectedNotification));
+            Assert.True(aToString.Contains(ReferenceLoopProneValueCollection<B>.LoopDetectedNotification));
         }
 
         [Test]
@@ -46,7 +44,7 @@ namespace Nemesis.Essentials.Tests
             var aToString = a.ToString();
 
             //Assert
-            Assert.False(aToString.Contains(LoopDetectedNotification));
+            Assert.False(aToString.Contains(ReferenceLoopProneValueCollection<B>.LoopDetectedNotification));
         }
     }
 }

--- a/Nemesis.Essentials/Design/ReferenceLoopProneValueCollection.cs
+++ b/Nemesis.Essentials/Design/ReferenceLoopProneValueCollection.cs
@@ -1,0 +1,28 @@
+﻿using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+
+namespace Nemesis.Essentials.Design
+{
+    public class ReferenceLoopProneValueCollection<T> : ValueCollection<T>
+    {
+        private const string LoopDetectedNotification = "## SELF REFERENCING LOOP DETECTED ##";
+
+        public ReferenceLoopProneValueCollection() : base(new List<T>()) { }
+
+        public ReferenceLoopProneValueCollection(IEqualityComparer<T> equalityComparer = null) : base(new List<T>(), equalityComparer) { }
+
+        public ReferenceLoopProneValueCollection(IList<T> list, IEqualityComparer<T> equalityComparer = null) : base(list) { }
+
+        public override string ToString() => CheckSelfReferencingLoop() ?? base.ToString();
+
+        private static string CheckSelfReferencingLoop()
+        {
+            StackTrace stackTrace = new();
+            var callerMethodHandleValue = stackTrace.GetFrame(1)?.GetMethod()?.MethodHandle.Value ?? default;
+            return stackTrace.GetFrames().Skip(2).Any(f => f.GetMethod()?.MethodHandle.Value == callerMethodHandleValue)
+                ? LoopDetectedNotification
+                : null;
+        }
+    }
+}

--- a/Nemesis.Essentials/Design/ReferenceLoopProneValueCollection.cs
+++ b/Nemesis.Essentials/Design/ReferenceLoopProneValueCollection.cs
@@ -9,7 +9,7 @@ namespace Nemesis.Essentials.Design
 {
     public class ReferenceLoopProneValueCollection<T> : ICollection<T>
     {
-        private const string LoopDetectedNotification = "## SELF REFERENCING LOOP DETECTED ##";
+        internal const string LoopDetectedNotification = "## SELF REFERENCING LOOP DETECTED ##";
 
         private readonly ValueCollection<T> _decoratee;
 


### PR DESCRIPTION
Proposing to add ReferenceLoopProneValueCollection in order to break possible reference loop in `ValueCollection` https://github.com/nemesissoft/Nemesis.Essentials/issues/2

Please, feel free to close it right away. Submitting it just to track possible solutions in case someone would hit it as well.